### PR TITLE
feat: add SonarQube analysis workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,40 @@
+name: Sonar
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  sonar:
+    # Skip fork PRs — secrets are unavailable for security reasons
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Run Sonar scan
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >-
+          ./gradlew assemble test jacocoRootReport sonar
+          -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+          -Dsonar.organization=${{ github.repository_owner }}

--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,14 @@ tasks.register('testReport', TestReport) {
 	destinationDirectory = layout.buildDirectory.dir("reports/allTests")
 }
 
+sonarqube {
+	properties {
+		property "sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/jacocoRootReport/jacocoRootReport.xml").get().asFile.path
+	}
+}
+
 tasks.sonarqube {
+	dependsOn jacocoRootReport
 	onlyIf {
 		System.properties.'sonar.organization' || System.env.SCRUTINIZER
 	}


### PR DESCRIPTION
Add a dedicated sonar.yml GitHub Actions workflow that runs tests,
generates the aggregate JaCoCo coverage report, and uploads results
to SonarCloud on push to master, PRs, and merge groups. Wire the
sonarqube task to depend on jacocoRootReport and configure the
coverage XML path so SonarCloud receives accurate coverage data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated code quality assurance with integrated testing and coverage analysis in the continuous integration pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fullsync/fullsync/pull/424)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->