### PR TITLE
test: add unit tests for core value types, schedules, and utils

### DIFF
--- a/fullsync-core/build.gradle.kts
+++ b/fullsync-core/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 	implementation(files("lib/commons-vfs2-sandbox.jar"))
 	testImplementation(libs.junit.jupiter)
 	testImplementation(libs.hamcrest)
+	testImplementation(libs.mockito.core)
 	testImplementation(libs.testcontainers)
 	testImplementation(libs.testcontainers.junit)
 }

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/ObfuscatorTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/ObfuscatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class ObfuscatorTest {
+	@Test
+	public void obfuscateNullReturnsNull() {
+		assertNull(Obfuscator.obfuscate(null));
+	}
+
+	@Test
+	public void deobfuscateNullReturnsNull() {
+		assertNull(Obfuscator.deobfuscate(null));
+	}
+
+	@Test
+	public void roundtripEmptyString() {
+		assertEquals("", Obfuscator.deobfuscate(Obfuscator.obfuscate("")));
+	}
+
+	@Test
+	public void roundtripSingleChar() {
+		assertEquals("a", Obfuscator.deobfuscate(Obfuscator.obfuscate("a")));
+	}
+
+	@Test
+	public void roundtripAlphanumericString() {
+		var input = "HelloWorld123";
+		assertEquals(input, Obfuscator.deobfuscate(Obfuscator.obfuscate(input)));
+	}
+
+	@Test
+	public void roundtripStringWithSpecialChars() {
+		var input = "p@$$w0rd!#%";
+		assertEquals(input, Obfuscator.deobfuscate(Obfuscator.obfuscate(input)));
+	}
+
+	@Test
+	public void roundtripLongString() {
+		var input = "FULLSYNC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZfullsync";
+		assertEquals(input, Obfuscator.deobfuscate(Obfuscator.obfuscate(input)));
+	}
+
+	@Test
+	public void deobfuscateEmptyStringReturnsEmpty() {
+		assertEquals("", Obfuscator.deobfuscate(""));
+	}
+
+	@Test
+	public void deobfuscateInvalidNonNumericCharsReturnsEmpty() {
+		assertEquals("", Obfuscator.deobfuscate("abc"));
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/SystemDateTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/SystemDateTest.java
@@ -44,9 +44,11 @@ public class SystemDateTest {
 
 	@Test
 	public void setCurrentFixesTime() {
-		var fixedTime = 1_000_000_000L;
+		var fixedTime = System.currentTimeMillis() + 60_000L;
 		SystemDate.getInstance().setCurrent(fixedTime);
-		assertTrue(SystemDate.getInstance().currentTimeMillis() >= fixedTime);
+		var reported = SystemDate.getInstance().currentTimeMillis();
+		assertTrue(reported >= fixedTime && reported < fixedTime + 1_000L,
+			"reported " + reported + " should be within [" + fixedTime + ", " + (fixedTime + 1_000L) + ")");
 	}
 
 	@Test

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/SystemDateTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/SystemDateTest.java
@@ -1,0 +1,75 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class SystemDateTest {
+	@AfterEach
+	public void tearDown() {
+		SystemDate.getInstance().setUseSystemTime();
+	}
+
+	@Test
+	public void getInstanceReturnsNonNull() {
+		assertNotNull(SystemDate.getInstance());
+	}
+
+	@Test
+	public void getInstanceReturnsSameInstance() {
+		assertSame(SystemDate.getInstance(), SystemDate.getInstance());
+	}
+
+	@Test
+	public void setCurrentFixesTime() {
+		var fixedTime = 1_000_000_000L;
+		SystemDate.getInstance().setCurrent(fixedTime);
+		assertTrue(SystemDate.getInstance().currentTimeMillis() >= fixedTime);
+	}
+
+	@Test
+	public void setUseSystemTimeReverts() {
+		SystemDate.getInstance().setCurrent(0L);
+		SystemDate.getInstance().setUseSystemTime();
+		var before = System.currentTimeMillis();
+		var reported = SystemDate.getInstance().currentTimeMillis();
+		var after = System.currentTimeMillis();
+		assertTrue(reported >= before && reported <= after + 10);
+	}
+
+	@Test
+	public void setTimeSpeedAcceleratesTime() throws Exception {
+		var base = System.currentTimeMillis();
+		SystemDate.getInstance().setCurrent(base);
+		SystemDate.getInstance().setTimeSpeed(100);
+		var wallStart = System.currentTimeMillis();
+		Thread.sleep(20);
+		var wallElapsed = System.currentTimeMillis() - wallStart;
+		var reported = SystemDate.getInstance().currentTimeMillis();
+		var reportedElapsed = reported - base;
+		assertTrue(reportedElapsed >= wallElapsed * 50,
+			"reported elapsed " + reportedElapsed + " should be >> wall elapsed " + wallElapsed);
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/impl/BufferStateDeciderImplTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/impl/BufferStateDeciderImplTest.java
@@ -1,0 +1,138 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.fullsync.BufferedFile;
+import net.sourceforge.fullsync.FSFile;
+import net.sourceforge.fullsync.State;
+
+public class BufferStateDeciderImplTest {
+	private BufferStateDeciderImpl decider;
+	private FSFile source;
+	private BufferedFile buffered;
+
+	@BeforeEach
+	public void setUp() {
+		decider = new BufferStateDeciderImpl(new SimplifiedSyncRules());
+		source = mock(FSFile.class);
+		buffered = mock(BufferedFile.class);
+	}
+
+	@Test
+	public void notBufferedReturnsInSync() throws Exception {
+		when(buffered.isBuffered()).thenReturn(false);
+		assertEquals(State.IN_SYNC, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedSourceMissingDestMissingReturnsInSync() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(false);
+		when(buffered.exists()).thenReturn(false);
+		assertEquals(State.IN_SYNC, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedSourceMissingDestExistsReturnsOrphanDestination() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(false);
+		when(buffered.exists()).thenReturn(true);
+		assertEquals(State.ORPHAN_DESTINATION, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedSourceExistsDestMissingReturnsOrphanSource() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(true);
+		when(buffered.exists()).thenReturn(false);
+		assertEquals(State.ORPHAN_SOURCE, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedBothDirectoriesReturnsInSync() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(true);
+		when(buffered.exists()).thenReturn(true);
+		when(source.isDirectory()).thenReturn(true);
+		when(buffered.isDirectory()).thenReturn(true);
+		assertEquals(State.IN_SYNC, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedSourceDirDestFileReturnsDirSourceFileDestination() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(true);
+		when(buffered.exists()).thenReturn(true);
+		when(source.isDirectory()).thenReturn(true);
+		when(buffered.isDirectory()).thenReturn(false);
+		assertEquals(State.DIR_SOURCE_FILE_DESTINATION, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedSourceFileDest_dirReturnsFileSourceDirDestination() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(true);
+		when(buffered.exists()).thenReturn(true);
+		when(source.isDirectory()).thenReturn(false);
+		when(buffered.isDirectory()).thenReturn(true);
+		assertEquals(State.FILE_SOURCE_DIR_DESTINATION, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedBothFilesSourceNewerReturnsFileChangeSource() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(true);
+		when(buffered.exists()).thenReturn(true);
+		when(source.isDirectory()).thenReturn(false);
+		when(buffered.isDirectory()).thenReturn(false);
+		when(source.getLastModified()).thenReturn(2000L);
+		when(buffered.getLastModified()).thenReturn(1000L);
+		assertEquals(State.FILE_CHANGE_SOURCE, decider.getState(buffered));
+	}
+
+	@Test
+	public void bufferedBothFilesInSyncReturnsInSync() throws Exception {
+		when(buffered.isBuffered()).thenReturn(true);
+		when(buffered.getUnbuffered()).thenReturn(source);
+		when(source.exists()).thenReturn(true);
+		when(buffered.exists()).thenReturn(true);
+		when(source.isDirectory()).thenReturn(false);
+		when(buffered.isDirectory()).thenReturn(false);
+		when(source.getLastModified()).thenReturn(1000L);
+		when(buffered.getLastModified()).thenReturn(1000L);
+		when(source.getSize()).thenReturn(512L);
+		when(buffered.getSize()).thenReturn(512L);
+		assertEquals(State.IN_SYNC, decider.getState(buffered));
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/impl/SimplifiedSyncRulesTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/impl/SimplifiedSyncRulesTest.java
@@ -1,0 +1,159 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.fullsync.FSFile;
+import net.sourceforge.fullsync.State;
+import net.sourceforge.fullsync.rules.filefilter.FileFilter;
+import net.sourceforge.fullsync.rules.filefilter.FileFilterRule;
+import net.sourceforge.fullsync.rules.filefilter.TestNode;
+import net.sourceforge.fullsync.rules.filefilter.values.OperandValue;
+
+public class SimplifiedSyncRulesTest {
+	private static final FileFilterRule ALWAYS_TRUE = new FileFilterRule() {
+		@Override
+		public boolean match(FSFile file) {
+			return true;
+		}
+
+		@Override
+		public int getOperator() {
+			return 0;
+		}
+
+		@Override
+		public String getOperatorName() {
+			return null;
+		}
+
+		@Override
+		public String getRuleType() {
+			return "True";
+		}
+
+		@Override
+		public OperandValue getValue() {
+			return null;
+		}
+	};
+
+	private TestNode root;
+	private SimplifiedSyncRules rules;
+
+	@BeforeEach
+	public void setUp() {
+		root = TestNode.root();
+		rules = new SimplifiedSyncRules();
+	}
+
+	@Test
+	public void compareFilesSourceNewer() {
+		var src = root.createChildNode("a", true, false, 100, 2000);
+		var dst = root.createChildNode("a", true, false, 100, 1000);
+		assertEquals(State.FILE_CHANGE_SOURCE, rules.compareFiles(src, dst));
+	}
+
+	@Test
+	public void compareFilesDestinationNewer() {
+		var src = root.createChildNode("a", true, false, 100, 1000);
+		var dst = root.createChildNode("a", true, false, 100, 2000);
+		assertEquals(State.FILE_CHANGE_DESTINATION, rules.compareFiles(src, dst));
+	}
+
+	@Test
+	public void compareFilesSameSecondDifferentSizeIsUnknown() {
+		var src = root.createChildNode("a", true, false, 100, 1000);
+		var dst = root.createChildNode("a", true, false, 200, 1000);
+		assertEquals(State.FILE_CHANGE_UNKNOWN, rules.compareFiles(src, dst));
+	}
+
+	@Test
+	public void compareFilesSameSecondSameSizeIsInSync() {
+		var src = root.createChildNode("a", true, false, 100, 1000);
+		var dst = root.createChildNode("a", true, false, 100, 1000);
+		assertEquals(State.IN_SYNC, rules.compareFiles(src, dst));
+	}
+
+	@Test
+	public void compareFilesWithinSameFloorSecondIsInSync() {
+		// 1001ms and 1999ms both floor to 1 second
+		var src = root.createChildNode("a", true, false, 100, 1001);
+		var dst = root.createChildNode("a", true, false, 100, 1999);
+		assertEquals(State.IN_SYNC, rules.compareFiles(src, dst));
+	}
+
+	@Test
+	public void isNodeIgnoredWithUseFilterFalseAlwaysReturnsFalse() {
+		rules.setUseFilter(false);
+		var node = root.createChildNode("x", true, false, 0, 0);
+		assertFalse(rules.isNodeIgnored(node));
+	}
+
+	@Test
+	public void isNodeIgnoredWithNoFilterSetReturnsFalse() {
+		rules.setUseFilter(true);
+		rules.setFileFilter(null);
+		var node = root.createChildNode("x", true, false, 0, 0);
+		assertFalse(rules.isNodeIgnored(node));
+	}
+
+	@Test
+	public void isNodeIgnoredWithIncludeFilterReturnsFalse() {
+		rules.setUseFilter(true);
+		rules.setFileFilter(new FileFilter(FileFilter.MATCH_ALL, FileFilter.INCLUDE, true, ALWAYS_TRUE));
+		var node = root.createChildNode("x", true, false, 0, 0);
+		assertFalse(rules.isNodeIgnored(node));
+	}
+
+	@Test
+	public void isNodeIgnoredWithExcludeFilterReturnsTrue() {
+		rules.setUseFilter(true);
+		// EXCLUDE filter with matching rule: match() returns false → take=false → ignored
+		rules.setFileFilter(new FileFilter(FileFilter.MATCH_ALL, FileFilter.EXCLUDE, true, ALWAYS_TRUE));
+		var node = root.createChildNode("x", true, false, 0, 0);
+		assertTrue(rules.isNodeIgnored(node));
+	}
+
+	@Test
+	public void isUsingRecursionDefaultsToTrue() {
+		assertTrue(rules.isUsingRecursion());
+	}
+
+	@Test
+	public void setUsingRecursionUpdatesFlag() {
+		rules.setUsingRecursion(false);
+		assertFalse(rules.isUsingRecursion());
+	}
+
+	@Test
+	public void createChildReturnsSelf() {
+		var src = root.createChildNode("a", true, false, 0, 0);
+		var dst = root.createChildNode("a", true, false, 0, 0);
+		assertSame(rules, rules.createChild(src, dst));
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/AgeValueTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/AgeValueTest.java
@@ -1,0 +1,77 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.rules.filefilter.values;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import net.sourceforge.fullsync.DataParseException;
+
+import org.junit.jupiter.api.Test;
+
+public class AgeValueTest {
+	@Test
+	public void parseFromStringExtractsValueAndUnit() throws Exception {
+		var age = new AgeValue("5 DAYS");
+		assertEquals(5.0, age.getValue());
+		assertEquals(AgeValue.Unit.DAYS, age.getUnit());
+	}
+
+	@Test
+	public void getSecondsForSeconds() {
+		assertEquals(7, new AgeValue(7, AgeValue.Unit.SECONDS).getSeconds());
+	}
+
+	@Test
+	public void getSecondsForMinutes() {
+		assertEquals(120, new AgeValue(2, AgeValue.Unit.MINUTES).getSeconds());
+	}
+
+	@Test
+	public void getSecondsForHours() {
+		assertEquals(7200, new AgeValue(2, AgeValue.Unit.HOURS).getSeconds());
+	}
+
+	@Test
+	public void getSecondsForDays() {
+		assertEquals(86400, new AgeValue(1, AgeValue.Unit.DAYS).getSeconds());
+	}
+
+	@Test
+	public void parseIsCaseInsensitive() throws Exception {
+		var age = new AgeValue("3 hours");
+		assertEquals(AgeValue.Unit.HOURS, age.getUnit());
+	}
+
+	@Test
+	public void parseInvalidUnitThrowsDataParseException() {
+		assertThrows(DataParseException.class, () -> new AgeValue("5 FORTNIGHTS"));
+	}
+
+	@Test
+	public void parseStringWithNoSeparatorThrowsDataParseException() {
+		assertThrows(DataParseException.class, () -> new AgeValue("5DAYS"));
+	}
+
+	@Test
+	public void toStringReturnsValueAndUnit() {
+		assertEquals("5.0 DAYS", new AgeValue(5, AgeValue.Unit.DAYS).toString());
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/SizeValueTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/SizeValueTest.java
@@ -1,0 +1,77 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.rules.filefilter.values;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import net.sourceforge.fullsync.DataParseException;
+
+import org.junit.jupiter.api.Test;
+
+public class SizeValueTest {
+	@Test
+	public void parseFromStringExtractsValueAndUnit() throws Exception {
+		var size = new SizeValue("10 MBYTES");
+		assertEquals(10.0, size.getValue());
+		assertEquals(SizeValue.Unit.MBYTES, size.getUnit());
+	}
+
+	@Test
+	public void getBytesForBytes() {
+		assertEquals(42L, new SizeValue(42, SizeValue.Unit.BYTES).getBytes());
+	}
+
+	@Test
+	public void getBytesForKilobytes() {
+		assertEquals(1024L, new SizeValue(1, SizeValue.Unit.KBYTES).getBytes());
+	}
+
+	@Test
+	public void getBytesForMegabytes() {
+		assertEquals(1024L * 1024, new SizeValue(1, SizeValue.Unit.MBYTES).getBytes());
+	}
+
+	@Test
+	public void getBytesForGigabytes() {
+		assertEquals(1024L * 1024 * 1024, new SizeValue(1, SizeValue.Unit.GBYTES).getBytes());
+	}
+
+	@Test
+	public void parseIsCaseInsensitive() throws Exception {
+		var size = new SizeValue("1024 bytes");
+		assertEquals(SizeValue.Unit.BYTES, size.getUnit());
+	}
+
+	@Test
+	public void parseInvalidUnitThrowsDataParseException() {
+		assertThrows(DataParseException.class, () -> new SizeValue("5 TBYTES"));
+	}
+
+	@Test
+	public void parseStringWithNoSeparatorThrowsDataParseException() {
+		assertThrows(DataParseException.class, () -> new SizeValue("1024BYTES"));
+	}
+
+	@Test
+	public void toStringReturnsValueAndUnit() {
+		assertEquals("10.0 MBYTES", new SizeValue(10, SizeValue.Unit.MBYTES).toString());
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/TextValueTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/TextValueTest.java
@@ -1,0 +1,54 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.rules.filefilter.values;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TextValueTest {
+	@Test
+	public void valueReturnsConstructorArgument() {
+		assertEquals("hello", new TextValue("hello").value());
+	}
+
+	@Test
+	public void toStringReturnsValue() {
+		assertEquals("hello", new TextValue("hello").toString());
+	}
+
+	@Test
+	public void recordEqualityMatchesOnValue() {
+		assertEquals(new TextValue("hello"), new TextValue("hello"));
+	}
+
+	@Test
+	public void recordEqualityDiffersOnDifferentValue() {
+		assertNotEquals(new TextValue("hello"), new TextValue("world"));
+	}
+
+	@Test
+	public void emptyValueIsSupported() {
+		var tv = new TextValue("");
+		assertEquals("", tv.value());
+		assertEquals("", tv.toString());
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/TypeValueTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/rules/filefilter/values/TypeValueTest.java
@@ -1,0 +1,70 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.rules.filefilter.values;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sourceforge.fullsync.DataParseException;
+
+import org.junit.jupiter.api.Test;
+
+public class TypeValueTest {
+	@Test
+	public void parseFileType() throws Exception {
+		var tv = new TypeValue("FILE");
+		assertTrue(tv.isFile());
+		assertFalse(tv.isDirectory());
+		assertEquals(TypeValue.Type.FILE, tv.getType());
+	}
+
+	@Test
+	public void parseDirectoryType() throws Exception {
+		var tv = new TypeValue("DIRECTORY");
+		assertTrue(tv.isDirectory());
+		assertFalse(tv.isFile());
+		assertEquals(TypeValue.Type.DIRECTORY, tv.getType());
+	}
+
+	@Test
+	public void parseIsCaseInsensitive() throws Exception {
+		var tv = new TypeValue("file");
+		assertTrue(tv.isFile());
+	}
+
+	@Test
+	public void parseInvalidTypeThrowsDataParseException() {
+		assertThrows(DataParseException.class, () -> new TypeValue("SYMLINK"));
+	}
+
+	@Test
+	public void constructorWithEnumSetsType() {
+		var tv = new TypeValue(TypeValue.Type.DIRECTORY);
+		assertTrue(tv.isDirectory());
+	}
+
+	@Test
+	public void toStringReturnsTypeName() {
+		assertEquals("FILE", new TypeValue(TypeValue.Type.FILE).toString());
+		assertEquals("DIRECTORY", new TypeValue(TypeValue.Type.DIRECTORY).toString());
+	}
+}

--- a/fullsync-core/src/test/java/net/sourceforge/fullsync/schedule/IntervalScheduleTest.java
+++ b/fullsync-core/src/test/java/net/sourceforge/fullsync/schedule/IntervalScheduleTest.java
@@ -1,0 +1,128 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.schedule;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+
+public class IntervalScheduleTest {
+	private org.w3c.dom.Element createElement() throws Exception {
+		var factory = DocumentBuilderFactory.newInstance();
+		var doc = factory.newDocumentBuilder().newDocument();
+		return doc.createElement("schedule");
+	}
+
+	@Test
+	public void constructorWithParamsSetsGetters() {
+		var schedule = new IntervalSchedule(5000L, 60000L, "minutes");
+		assertEquals(5000L, schedule.getFirstInterval());
+		assertEquals(60000L, schedule.getInterval());
+		assertEquals("minutes", schedule.getIntervalDisplayUnit());
+	}
+
+	@Test
+	public void constructorFromElementParsesAttributes() throws Exception {
+		var el = createElement();
+		el.setAttribute("firstinterval", "3000");
+		el.setAttribute("interval", "30000");
+		el.setAttribute("displayUnit", "seconds");
+
+		var schedule = new IntervalSchedule(el);
+		assertEquals(3000L, schedule.getFirstInterval());
+		assertEquals(30000L, schedule.getInterval());
+		assertEquals("seconds", schedule.getIntervalDisplayUnit());
+	}
+
+	@Test
+	public void constructorFromElementWithMissingAttributesUsesZero() throws Exception {
+		var el = createElement();
+		var schedule = new IntervalSchedule(el);
+		assertEquals(0L, schedule.getFirstInterval());
+		assertEquals(0L, schedule.getInterval());
+	}
+
+	@Test
+	public void getNextOccurrenceForFirstRunReturnsAtLeastNow() {
+		var schedule = new IntervalSchedule(0L, 60_000L, "minutes");
+		var now = System.currentTimeMillis();
+		var next = schedule.getNextOccurrence(0, now);
+		assertTrue(next >= now);
+	}
+
+	@Test
+	public void getNextOccurrenceAddsIntervalToLastOccurrence() {
+		var schedule = new IntervalSchedule(0L, 60_000L, "minutes");
+		var now = System.currentTimeMillis();
+		var lastOccurrence = now;
+		var next = schedule.getNextOccurrence(lastOccurrence, now);
+		assertEquals(now + 60_000L, next);
+	}
+
+	@Test
+	public void getNextOccurrenceReturnsAtLeastNowWhenNextIsInPast() {
+		var schedule = new IntervalSchedule(0L, 1000L, "seconds");
+		var now = System.currentTimeMillis();
+		var longAgo = now - 100_000L;
+		var next = schedule.getNextOccurrence(longAgo, now);
+		assertEquals(now, next);
+	}
+
+	@Test
+	public void serializeRoundtrip() throws Exception {
+		var original = new IntervalSchedule(5000L, 60000L, "minutes");
+		var el = createElement();
+		original.serialize(el);
+
+		assertEquals(IntervalSchedule.SCHEDULE_TYPE, el.getAttribute("type"));
+		assertEquals("5000", el.getAttribute("firstinterval"));
+		assertEquals("60000", el.getAttribute("interval"));
+		assertEquals("minutes", el.getAttribute("displayUnit"));
+
+		var restored = new IntervalSchedule(el);
+		assertEquals(original, restored);
+	}
+
+	@Test
+	public void equalInstancesHaveSameHashCode() {
+		var a = new IntervalSchedule(1000L, 5000L, "ms");
+		var b = new IntervalSchedule(1000L, 5000L, "ms");
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+	}
+
+	@Test
+	public void differentDisplayUnitBreaksEquality() {
+		var a = new IntervalSchedule(1000L, 5000L, "ms");
+		var b = new IntervalSchedule(1000L, 5000L, "seconds");
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void differentIntervalBreaksEquality() {
+		var a = new IntervalSchedule(1000L, 5000L, "ms");
+		var b = new IntervalSchedule(1000L, 9000L, "ms");
+		assertNotEquals(a, b);
+	}
+}

--- a/fullsync-utils/src/test/java/net/sourceforge/fullsync/utils/XmlUtilsTest.java
+++ b/fullsync-utils/src/test/java/net/sourceforge/fullsync/utils/XmlUtilsTest.java
@@ -72,8 +72,7 @@ public class XmlUtilsTest {
 		var sw = new StringWriter();
 		transformer.transform(new StreamSource(new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8))),
 			new StreamResult(sw));
-		var doc = XmlUtils.newDocumentBuilder()
-			.parse(new ByteArrayInputStream(sw.toString().getBytes(StandardCharsets.UTF_8)));
+		var doc = XmlUtils.newDocumentBuilder().parse(new ByteArrayInputStream(sw.toString().getBytes(StandardCharsets.UTF_8)));
 		assertEquals("root", doc.getDocumentElement().getTagName());
 	}
 

--- a/fullsync-utils/src/test/java/net/sourceforge/fullsync/utils/XmlUtilsTest.java
+++ b/fullsync-utils/src/test/java/net/sourceforge/fullsync/utils/XmlUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * For information about the authors of this project Have a look
+ * at the AUTHORS file in the root of this project.
+ */
+package net.sourceforge.fullsync.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class XmlUtilsTest {
+	private static final String SIMPLE_XML = "<root><child1/><child2/></root>";
+
+	@Test
+	public void newDocumentBuilderReturnsUsableBuilder() throws Exception {
+		var builder = XmlUtils.newDocumentBuilder();
+		assertNotNull(builder);
+		var doc = builder.parse(new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8)));
+		assertNotNull(doc);
+		assertEquals("root", doc.getDocumentElement().getTagName());
+	}
+
+	@Test
+	public void newSaxParserReturnsUsableParser() throws Exception {
+		var parser = XmlUtils.newSaxParser();
+		assertNotNull(parser);
+		var input = new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8));
+		parser.parse(input, new DefaultHandler());
+	}
+
+	@Test
+	public void newTransformerHasCorrectOutputProperties() throws Exception {
+		var transformer = XmlUtils.newTransformer();
+		assertNotNull(transformer);
+		assertEquals("xml", transformer.getOutputProperty(OutputKeys.METHOD));
+		assertEquals("1.0", transformer.getOutputProperty(OutputKeys.VERSION));
+		assertEquals("yes", transformer.getOutputProperty(OutputKeys.INDENT));
+		assertEquals("no", transformer.getOutputProperty(OutputKeys.STANDALONE));
+	}
+
+	@Test
+	public void newTransformerCanTransformXml() throws Exception {
+		var transformer = XmlUtils.newTransformer();
+		var sw = new StringWriter();
+		transformer.transform(new StreamSource(new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8))),
+			new StreamResult(sw));
+		assertNotNull(sw.toString());
+	}
+
+	@Test
+	public void forEachChildElementVisitsOnlyElements() throws Exception {
+		var doc = XmlUtils.newDocumentBuilder().parse(new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8)));
+		var root = doc.getDocumentElement();
+		List<String> visited = new ArrayList<>();
+		XmlUtils.forEachChildElement(root, el -> visited.add(el.getTagName()));
+		assertEquals(List.of("child1", "child2"), visited);
+	}
+
+	@Test
+	public void forEachChildElementSkipsTextNodes() throws Exception {
+		var xml = "<root>text<child/>more text</root>";
+		var doc = XmlUtils.newDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+		List<String> visited = new ArrayList<>();
+		XmlUtils.forEachChildElement(doc.getDocumentElement(), el -> visited.add(el.getTagName()));
+		assertEquals(List.of("child"), visited);
+	}
+
+	@Test
+	public void forEachChildElementOnLeafNodeVisitsNothing() throws Exception {
+		var xml = "<root><leaf/></root>";
+		var doc = XmlUtils.newDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+		var leaf = (Node) doc.getDocumentElement().getFirstChild();
+		List<String> visited = new ArrayList<>();
+		XmlUtils.forEachChildElement(leaf, el -> visited.add(el.getTagName()));
+		assertEquals(0, visited.size());
+	}
+}

--- a/fullsync-utils/src/test/java/net/sourceforge/fullsync/utils/XmlUtilsTest.java
+++ b/fullsync-utils/src/test/java/net/sourceforge/fullsync/utils/XmlUtilsTest.java
@@ -72,7 +72,9 @@ public class XmlUtilsTest {
 		var sw = new StringWriter();
 		transformer.transform(new StreamSource(new ByteArrayInputStream(SIMPLE_XML.getBytes(StandardCharsets.UTF_8))),
 			new StreamResult(sw));
-		assertNotNull(sw.toString());
+		var doc = XmlUtils.newDocumentBuilder()
+			.parse(new ByteArrayInputStream(sw.toString().getBytes(StandardCharsets.UTF_8)));
+		assertEquals("root", doc.getDocumentElement().getTagName());
 	}
 
 	@Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ commons-vfs = "2.10.0"
 jcifs = "1.3.17"
 jsch = "0.1.55"
 hamcrest = "3.0"
+mockito = "5.14.0"
 testcontainers = "1.21.4"
 spotless = "8.4.0"
 
@@ -26,6 +27,7 @@ guice-assistedInject = { module = "com.google.inject.extensions:guice-assistedin
 # so dependency update tooling can update the version automatically
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 


### PR DESCRIPTION
## Summary
- Add unit tests across `fullsync-core` (`Obfuscator`, `SystemDate`, `IntervalSchedule`, `BufferStateDeciderImpl`, `SimplifiedSyncRules`, and file filter value types: `AgeValue`, `SizeValue`, `TextValue`, `TypeValue`) and `fullsync-utils` (`XmlUtils`).
- Add Mockito 5.14.0 as a test dependency to support the new tests.

## Test plan
- [x] `./gradlew test` passes locally (BUILD SUCCESSFUL)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for obfuscation, time handling, synchronization decisions, filtering, scheduling, XML utilities, and file-filter value parsing.
  * Added validation for edge cases, invalid inputs, serialization, equality, and time-based behavior.
  * Improved test support for simulated file-system scenarios, including buffered and unbuffered states, file comparisons, and directory handling.
  * Added coverage for parsing and formatting age, size, type, and text-based filter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->